### PR TITLE
fix: Edit message type in RequestCourtDocumentParse emitted by pre parser

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/tre/MessageParsingUtils.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tre/MessageParsingUtils.scala
@@ -34,7 +34,7 @@ object MessageParsingUtils {
   ): String = {
     RequestCourtDocumentParse(
       properties = Properties(
-        messageType = "uk.gov.nationalarchives.tre.messages.courtdocument.parse.RequestCourtDocumentParse",
+        messageType = "uk.gov.nationalarchives.tre.messages.request.courtdocument.parse.RequestCourtDocumentParse",
         timestamp = timestamp,
         function = "da-tre-fn-court-document-pre-parser",
         producer = TRE,

--- a/src/main/scala/uk/gov/nationalarchives/tre/MessageParsingUtils.scala
+++ b/src/main/scala/uk/gov/nationalarchives/tre/MessageParsingUtils.scala
@@ -34,7 +34,7 @@ object MessageParsingUtils {
   ): String = {
     RequestCourtDocumentParse(
       properties = Properties(
-        messageType = "uk.gov.nationalarchives.da.messages.request.courtdocument.parse.RequestCourtDocumentParse",
+        messageType = "uk.gov.nationalarchives.tre.messages.courtdocument.parse.RequestCourtDocumentParse",
         timestamp = timestamp,
         function = "da-tre-fn-court-document-pre-parser",
         producer = TRE,

--- a/src/test/scala/uk/gov/nationalarchives/tre/BagValidateMessageHandlerSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/tre/BagValidateMessageHandlerSpec.scala
@@ -48,7 +48,7 @@ class BagValidateMessageHandlerSpec extends AnyFlatSpec with MockitoSugar {
 
   "BagValidateMessageHandler" should "return a RequestCourtDocumentParse message with the correct input file location" in {
     val requestCourtDocumentParseString = messageHandler.handleBagValidate(requestWithInputData.bagValidateMessage)
-    JsonPath.read[String](requestCourtDocumentParseString, "$.properties.messageType") should be ("uk.gov.nationalarchives.da.messages.request.courtdocument.parse.RequestCourtDocumentParse")
+    JsonPath.read[String](requestCourtDocumentParseString, "$.properties.messageType") should be ("uk.gov.nationalarchives.tre.messages.courtdocument.parse.RequestCourtDocumentParse")
     JsonPath.read[String](requestCourtDocumentParseString, "$.parameters.s3Bucket") should be ("tre-common-data")
     JsonPath.read[String](requestCourtDocumentParseString, "$.parameters.s3Key") should be ("TDR-2023-X1/001/TDR-2023-X1/data/test.docx")
   }


### PR DESCRIPTION
This isn't actually the correct message type, it's a non existent message type, but it is the message type string used in the filters when we set up our terraform environments. I will return to fix that (we will need to notify FCL I think), but in the meantime this fixes the TDR pipeline testing.