### PR TITLE
update to sbt.version 1.9.8 fails

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.9.8
+sbt.version = 1.9.7


### PR DESCRIPTION
reverting scala steward request whilst looking into 
Error: 5.129 [error] [launcher] error during sbt launcher: java.lang.UnsatisfiedLinkError: Error looking up function 'stat': java: undefined symbol: stat